### PR TITLE
Fix model not being saved

### DIFF
--- a/src/LakeDawson/Vocal/Vocal.php
+++ b/src/LakeDawson/Vocal/Vocal.php
@@ -422,6 +422,14 @@ class Vocal extends Model
         // If record is invalid, save is unsuccessful
         if ( ! $valid) return false;
 
+        foreach ($data as $key => $value)
+        {
+            if (isset($this->attributes[$key]))
+            {
+                $this->attributes[$key] = $value;
+            }
+        }
+
         // Hash attributes
         if (count($this->hashAttributes))
         {


### PR DESCRIPTION
I was struggling to make a simple model save since yesterday, relations wasn't working either, but first I was just trying to make the parent to save, so I went to the Vocal code and could not find where `$data` was being used in the saving routine. Added this code to my fork and now it (parent saving) works fine. 

Since this is something really basic, I'm still wondering if I wasn't doing something wrong. Basically I had all my data in the request, which was correctly loaded by `saveRecursive()`, it was just not being used by `save()`.
