### PR TITLE
Changed name of the hydrate function

### DIFF
--- a/src/LakeDawson/Vocal/Vocal.php
+++ b/src/LakeDawson/Vocal/Vocal.php
@@ -332,7 +332,7 @@ class Vocal extends Model
      * @param array $data
      * @return void
      */
-    private function hydrate($data)
+    private function hydrateModel($data)
     {
         $this->fill($data);
         $this->_hydratedByVocal = true;
@@ -610,7 +610,7 @@ class Vocal extends Model
             // If we don't have any data passed, use input
             if ( ! count($data)) $data = Input::all();
 
-            $this->hydrate($data);
+            $this->hydrateModel($data);
         }
 
         // If we have no rules, we're good to go!


### PR DESCRIPTION
The Illuminate\Database\Eloquent\Model class now has a function hydrate
Therefore an exception is raised:
Cannot make static method Illuminate\Database\Eloquent\Model::hydrate() non static in class LakeDawson\Vocal\Vocal
