### PR TITLE
[fix] belongsTo relationships don't work

### DIFF
--- a/src/Sjdaws/Vocal/Vocal.php
+++ b/src/Sjdaws/Vocal/Vocal.php
@@ -785,7 +785,11 @@ class Vocal extends Model
                 // Save record on success, log errors on fail
                 if ($result)
                 {
-                    if (method_exists($this->$modelClass(), 'associate')) $this->$modelClass()->associate($record)->forceSave();
+                    if (method_exists($this->$modelClass(), 'associate')) {
+                        // we must save the record first before associating it
+                        $record->forceSave();
+                        $this->$modelClass()->associate($record)->forceSave();
+                    } 
                     else
                     {
                         $result = $this->$modelClass()->saveRelation($record);

--- a/tests/Migrations/2014_04_02_090800_create_test_child_table.php
+++ b/tests/Migrations/2014_04_02_090800_create_test_child_table.php
@@ -22,7 +22,7 @@ class CreateTestChildTable extends Migration
 		Schema::create($this->table, function($t)
 		{
 			$t->increments('id')->unsigned();
-			$t->integer('test_id')->unsigned();
+			$t->integer('test_id')->unsigned()->nullable();
 			$t->string('description', 100);
 			$t->timestamps();
         });

--- a/tests/VocalTest.php
+++ b/tests/VocalTest.php
@@ -156,5 +156,22 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertTrue($result, $this->errorResponse('Record was not saved', $test));
 
         $this->assertTrue($test->password && $test->password != $input->get('password'), $this->errorResponse('Record was not saved', $test));
+
+        // Test that the inverse relationship (belongsTo) works
+        $input->replace(array(
+            'description' => 'Child 3',
+            'parent' => array(
+                'description' => 'Parent 2',
+            )
+        ));
+
+        $child = new TestChild;
+        $result = $child->saveRecursive();
+
+        // Make sure validation passed
+        $this->assertTrue($result, $this->errorResponse('Record was not saved', $child));
+
+        // Make sure the parent has an ID (that means it was actually saved)
+        $this->assertTrue(!!$child->parent->id, true);
     }
 }


### PR DESCRIPTION
I had this big long issue created explaining what I'd done to discover this issue, and then I'm all like, "Hey, I think I can fix this issue. I'll submit this and then create a PR," and then I hit **Fork** right there... which navigated away from the issue. Tried hitting back, but it was too late.

So I'm too tired to go into full detail, but the bottom line, it seems like `$this->$modelClass()->associate($record)->forceSave();` assumed that it saves the `$record` before associating it first, but it _does not_.

I added a test that if ran without my changes will fail (`parent` doesn't get created, and thus doesn't have an ID). If you run the tests again with my change (which saves the record before associating it), it works.
